### PR TITLE
change testsuite name

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,7 @@
 	verbose="true"
 	>
 	<testsuites>
-		<testsuite name="zapier">
+		<testsuite name="payments">
 			<directory prefix="test_" suffix=".php">./tests/</directory>
 		</testsuite>
 	</testsuites>


### PR DESCRIPTION
Tiny tweak, got merged pretty quick, noticed that I had copied the testsuite name from zapier.