### PR TITLE
undefined array key when creating an action fix

### DIFF
--- a/models/FrmTransAction.php
+++ b/models/FrmTransAction.php
@@ -221,9 +221,10 @@ class FrmTransAction extends FrmFormAction {
 				if ( ! empty( $field_atts['allowed_fields'] ) && ! in_array( $field->type, (array) $field_atts['allowed_fields'] ) ) {
 					continue;
 				}
-				$has_field = true;
+				$has_field  = true;
+				$key_exists = array_key_exists( $field_atts['name'], $form_atts['form_action']->post_content );
                 ?>
-                <option value="<?php echo esc_attr( $field->id ); ?>" <?php selected( $form_atts['form_action']->post_content[ $field_atts['name'] ], $field->id ); ?>>
+                <option value="<?php echo esc_attr( $field->id ); ?>" <?php selected( $key_exists ? $form_atts['form_action']->post_content[ $field_atts['name'] ] : 0, $field->id ); ?>>
 					<?php echo esc_attr( FrmAppHelper::truncate( $field->name, 50, 1 ) ); ?>
                 </option>
                 <?php


### PR DESCRIPTION
Doing some Stripe QA I noticed a ton of warnings come from the payments plugin when you add a form action.

```
[18-Jan-2021 20:29:42 UTC] PHP Warning:  Undefined array key "routing_num" in /var/www/src/wp-content/plugins/formidable-stripe/formidable-payments/models/FrmTransAction.php on line 226
[18-Jan-2021 20:29:42 UTC] PHP Warning:  Undefined array key "routing_num" in /var/www/src/wp-content/plugins/formidable-stripe/formidable-payments/models/FrmTransAction.php on line 226
[18-Jan-2021 20:29:42 UTC] PHP Warning:  Undefined array key "routing_num" in /var/www/src/wp-content/plugins/formidable-stripe/formidable-payments/models/FrmTransAction.php on line 226
[18-Jan-2021 20:29:42 UTC] PHP Warning:  Undefined array key "routing_num" in /var/www/src/wp-content/plugins/formidable-stripe/formidable-payments/models/FrmTransAction.php on line 226
[18-Jan-2021 20:29:42 UTC] PHP Warning:  Undefined array key "account_num" in /var/www/src/wp-content/plugins/formidable-stripe/formidable-payments/models/FrmTransAction.php on line 226
[18-Jan-2021 20:29:42 UTC] PHP Warning:  Undefined array key "account_num" in /var/www/src/wp-content/plugins/formidable-stripe/formidable-payments/models/FrmTransAction.php on line 226
[18-Jan-2021 20:29:42 UTC] PHP Warning:  Undefined array key "account_num" in /var/www/src/wp-content/plugins/formidable-stripe/formidable-payments/models/FrmTransAction.php on line 226
[18-Jan-2021 20:29:42 UTC] PHP Warning:  Undefined array key "account_num" in /var/www/src/wp-content/plugins/formidable-stripe/formidable-payments/models/FrmTransAction.php on line 226
[18-Jan-2021 20:29:42 UTC] PHP Warning:  Undefined array key "bank_name" in /var/www/src/wp-content/plugins/formidable-stripe/formidable-payments/models/FrmTransAction.php on line 226
[18-Jan-2021 20:29:42 UTC] PHP Warning:  Undefined array key "bank_name" in /var/www/src/wp-content/plugins/formidable-stripe/formidable-payments/models/FrmTransAction.php on line 226
[18-Jan-2021 20:29:42 UTC] PHP Warning:  Undefined array key "bank_name" in /var/www/src/wp-content/plugins/formidable-stripe/formidable-payments/models/FrmTransAction.php on line 226
[18-Jan-2021 20:29:42 UTC] PHP Warning:  Undefined array key "bank_name" in /var/www/src/wp-content/plugins/formidable-stripe/formidable-payments/models/FrmTransAction.php on line 226
```

It looks like it's checking for Authorize.Net data, but this is Stripe. It's not there.