### PR TITLE
check for amount length before accessing at index 0 fix

### DIFF
--- a/controllers/FrmTransActionsController.php
+++ b/controllers/FrmTransActionsController.php
@@ -267,7 +267,7 @@ class FrmTransActionsController {
 			$amount = FrmTransAppHelper::process_shortcodes( $atts );
 		}
 
-		if ( $amount[0] == '[' && substr( $amount, -1 ) == ']' ) {
+		if ( strlen( $amount ) >= 2 && $amount[0] == '[' && substr( $amount, -1 ) == ']' ) {
 			// make sure we don't use a field id as the amount
 			$amount = 0;
 		}


### PR DESCRIPTION
Fixes:
```
[04-Mar-2021 16:43:07 UTC] PHP Warning:  Uninitialized string offset 0 in /var/www/src/wp-content/plugins/formidable-stripe/formidable-payments/controllers/FrmTransActionsController.php on line 270
```

**The replicate**: Save a Stripe action with an empty amount field value.